### PR TITLE
修复在拖放元素的父元素offset不为0时，元素和代理元素位置不一致

### DIFF
--- a/index.js
+++ b/index.js
@@ -424,8 +424,8 @@ function executeRevert() {
             xtop = (isNaN(parseInt(element.css('top'), 10)) ? 0 : 
                     parseInt(element.css('top'), 10)) + xtop;
         } else if (element.css('position') === 'absolute') {
-            xleft = proxy.offset().left;
-            xtop = proxy.offset().top;
+            xleft = proxy.offset().left - originx;
+            xtop = proxy.offset().top - originy;
         } else {
             element.css('position', 'relative');
         }


### PR DESCRIPTION
```
<div style="position: relative; margin: 100px; width: 200px; height: 200px;">
    <div id="dragElement"></div>
</div>
//在此结构原始元素和代理元素会出现100px的位移
```
