### PR TITLE
fix README.md and chaotic proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Build Status](https://secure.travis-ci.org/aralejs/dnd.png)](https://travis-ci.org/aralejs/dnd)
 [![Coverage Status](https://coveralls.io/repos/aralejs/dnd/badge.png?branch=master)](https://coveralls.io/r/aralejs/dnd)
 
-Drap & Drop
+Drag & Drop
 
 ## 配置说明
 
@@ -45,7 +45,7 @@ Drap & Drop
 返回速度, 默认为500
 >注: 源节点显示(visible = true)时, 拖放结束时移动到拖放位置的速度也取此值
 
-#### draqCursor *string*
+#### dragCursor *string*
 拖放过程中没进入放置容器drop时光标形状, 默认为"move"
 
 #### dropCursor *string*

--- a/index.js
+++ b/index.js
@@ -97,6 +97,11 @@ function handleEvent(event) {
     switch(event.type) {
         case 'mousedown':
             if (event.which === 1) {
+                // 如果上次拖放未执行完则返回
+                if (proxy) {
+                    event.preventDefault();
+                    return;
+                }
 
                 // 检测并执行预拖放
                 executeDragPre({


### PR DESCRIPTION
1.  README.md文件“Drag"误拼为”Drap";
2.  proxy元素是可以拖拽的（在返回源节点初始位置途中操作）；
3.  多元素快速切换拖拽时，代理元素混乱；

简单粗暴的检测proxy元素是否存在，已确定是否执行拖拽行为；
